### PR TITLE
Enhancements from the SciPy Dev Summit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42.0.0", "wheel"]
+requires = ["setuptools>=42.0.0", "tiled[array,minimal-client]", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [options.entry_points]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,11 @@
 requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[options.entry_points]
+napari.manifest = "napari_tiled_browser:napari.yaml"
 
+[options.package_data]
+napari-tiled = "napari.yaml"
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,9 @@ requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = napari-tiled
-depedencies = ["tiled[array,minimal-client]"]
+name = "napari-tiled"
+version = "0"  # HACK
+dependencies = ["tiled[array,minimal-client]"]
 
 [options.entry_points]
 napari.manifest = "napari_tiled_browser:napari.yaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
-requires = ["setuptools>=42.0.0", "tiled[array,minimal-client]", "wheel"]
+requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = napari-tiled
+depedencies = ["tiled[array,minimal-client]"]
 
 [options.entry_points]
 napari.manifest = "napari_tiled_browser:napari.yaml"

--- a/src/napari_tiled_browser/tiled_widget.py
+++ b/src/napari_tiled_browser/tiled_widget.py
@@ -155,19 +155,12 @@ class TiledBrowser(QWidget):
             self.catalog_table.insertRow(last_row_position)
 
     def _populate_table(self):
-        print(f"{self.catalog_table.rowCount() = }")
-        for row_index in range(self.catalog_table.rowCount()):
-            node_index = self._rows_per_page * self._current_page + row_index
-            print(f"{node_index = }")
-            if node_index < len(self.catalog):
-                if isinstance(self.catalog, list):
-                    node = self.catalog[node_index]
-                else:
-                    # Node, CatalogOfBlueskyRuns, etc.
-                    node = self.catalog.keys()[node_index]
-            else:
-                node = ""
-            self.catalog_table.setItem(row_index, 0, QTableWidgetItem(node))
+        node_offset = self._rows_per_page * self._current_page
+        # Fetch a page of keys.
+        keys = self.catalog.keys()[node_offset:node_offset + self._rows_per_page]
+        # Loop over rows, filling in keys until we run out of keys.
+        for row_index, key in zip(range(self.catalog_table.rowCount()), keys):
+            self.catalog_table.setItem(row_index, 0, QTableWidgetItem(key))
 
     def _on_prev_page_clicked(self):
         if self._current_page != 0:


### PR DESCRIPTION
At the [Scientific Python Developer Summit](https://scientific-python.org/summits/developer/2023/) I connected with Napari Contributor Kira Evans, @kne42. This PR is mostly her work. It adds:

* Ability to navigate down (and up) through nodes
* Breadcrumbs
* Icons based on structure family
* Metadata display pane
* Click to view metadata; double-click to enter a node or open an image (i.e. array)
* Automatic reasonable default contrast limits

![napari-tiled-screenshot](https://github.com/AbbyGi/napari-tiled/assets/2279598/b3322003-c110-4bc7-9960-11412f40ada0)

During the live demo at the summit, we hit a bug, but the issue is on the server side, tracked here: https://github.com/bluesky/databroker/issues/767. No action required in this plugin.
