### PR TITLE
enter_node results

### DIFF
--- a/src/napari_tiled_browser/models/tiled_selector.py
+++ b/src/napari_tiled_browser/models/tiled_selector.py
@@ -15,6 +15,16 @@ from tiled.queries import FullText, Key, Regex
 from tiled.structures.core import StructureFamily
 
 _logger = logging.getLogger(__name__)
+_logger.setLevel(logging.DEBUG)
+
+console = logging.StreamHandler()
+console.setLevel(logging.DEBUG)
+formatter = logging.Formatter(
+    '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+    datefmt='%m-%d %H:%M:%S',
+)
+console.setFormatter(formatter)
+_logger.addHandler(console)
 
 
 def json_decode(obj):
@@ -271,12 +281,16 @@ class TiledSelector:
 
     def get_parent_node(self, node_path_parts: tuple[str]) -> list:
         """Fetch a node from Tiled corresponding to the node path."""
+        print(f"TiledSelector.get_parent_node({node_path_parts})...")
         # NOTE: Passing tiled a tuple returns a list of bluesky runs
         # even if there is only one item in the tuple
         # This may change in the future when the capability to pass a list
         # of uids to tiled is removed
         if node_path_parts:
-            return self.client[node_path_parts[0]]
+            print(f"  {self.client[node_path_parts[0]] = }")
+            print(f"  {self.client[node_path_parts] = }")
+            # return self.client[node_path_parts[0]]
+            return self.client[node_path_parts]
 
         # An empty tuple indicates the root node
         return self.client
@@ -328,11 +342,13 @@ class TiledSelector:
     def open_node(self, child_node_path: str) -> None:
         """Select a child node if its Tiled structure_family is supported."""
         node = self.get_current_node()[child_node_path]
+        _logger.debug(f"New node: {node.uri}")
         family = node.item["attributes"]["structure_family"]
 
         if family == StructureFamily.array:
             _logger.info("Found array, plotting TODO")
         elif family == StructureFamily.container:
+            _logger.debug(f"Entering container: {child_node_path}")
             self.enter_node(child_node_path)
         else:
             print(f"StructureFamily not supported:'{family}")

--- a/src/napari_tiled_browser/models/tiled_worker.py
+++ b/src/napari_tiled_browser/models/tiled_worker.py
@@ -36,7 +36,7 @@ class TiledWorker(QRunnable):
 
         if self.node_path_parts:
             results = catalog_or_search_results[
-                self.node_path_parts[0]
+                self.node_path_parts
             ].items()[selection]
         else:
             results = catalog_or_search_results.items()[selection]

--- a/src/napari_tiled_browser/qt/tiled_widget.py
+++ b/src/napari_tiled_browser/qt/tiled_widget.py
@@ -181,6 +181,7 @@ class QTiledBrowser(QWidget):
 
     def _rebuild_current_path_layout(self):
         """Reset the clickable widgets for the current path breadcrumbs."""
+        print("QTiledBrowser._rebuild_current_path_layout()...")
         bc_widget = ClickableIndexedQLabel("root", index=0)
         bc_widget.setObjectName("root")
         # bc_widget.clicked.connect(self._on_breadcrumb_clicked)
@@ -225,6 +226,7 @@ class QTiledBrowser(QWidget):
     def fetch_table_data(self):
         print(f"!!!       {self.model.client = }")
         print(f"!!! {self.model.node_path_parts = }")
+        print(f"!!!  {self.model.search_results = }")
         runnable = TiledWorker(
             rows_per_page=self.model.rows_per_page,
             current_page=self.model._current_page,
@@ -236,6 +238,7 @@ class QTiledBrowser(QWidget):
         self.thread_pool.start(runnable)
 
     def populate_table(self, results):
+        print("QTiledBrowser.populate_table()...")
         original_state = {}
         self.search_widget.setVisible(True)
         self.catalog_table_widget.setVisible(True)
@@ -296,6 +299,7 @@ class QTiledBrowser(QWidget):
         self.catalog_table.setVerticalHeaderLabels(headers)
         self._clear_metadata()
         self.catalog_table.blockSignals(original_state["blockSignals"])
+        self._set_current_location_label()
 
     def connect_model_signals(self):
         """Connect dialog slots to model signals."""
@@ -317,7 +321,7 @@ class QTiledBrowser(QWidget):
             if self.model.client is None:
                 # TODO: handle disconnecting from tiled client later
                 return
-            self._set_current_location_label()
+            # self._set_current_location_label()
             self.fetch_table_data()
             self._rebuild_current_path_layout()
 
@@ -526,6 +530,7 @@ class QTiledBrowser(QWidget):
     #         self._rebuild()
 
     def _set_current_location_label(self):
+        print("QTiledBrowser._set_current_location_label()...")
         starting_index = (
             self.model._current_page * self.model.rows_per_page + 1
         )


### PR DESCRIPTION
These changes fix navigation of the nodes.

However, search results fail with the message: "The key lookup query must never return more than one result."
https://github.com/bluesky/tiled/blob/fb40f0837bd08ee193a613068ebba3d270353141/tiled/client/container.py#L299